### PR TITLE
Add direction bias search option

### DIFF
--- a/src/dijkstra.ts
+++ b/src/dijkstra.ts
@@ -3,10 +3,22 @@ import { Key, Vertices } from "./types";
 
 type State = [number, Key[], Key];
 
+type DirectionBiasEvaluator = (input: {
+  cost: number;
+  from: Key;
+  to: Key;
+  path: Key[];
+}) => number;
+
+type Options = {
+  directionBias?: DirectionBiasEvaluator;
+};
+
 export default function findPath(
   graph: Vertices,
   start: Key,
-  end: Key
+  end: Key,
+  options: Options = {}
 ): [number, Key[]] | undefined {
   const costs: Record<Key, number> = { [start]: 0 };
   const initialState: State = [0, [start], start];
@@ -26,7 +38,15 @@ export default function findPath(
 
     const neighbours = graph[node];
     Object.keys(neighbours).forEach(function (n) {
-      var newCost = cost + neighbours[n];
+      const bias = options.directionBias
+        ? options.directionBias({
+            cost,
+            from: node,
+            to: n,
+            path: state[1],
+          })
+        : 0;
+      var newCost = cost + neighbours[n] + bias;
       if (newCost < Infinity && (!(n in costs) || newCost < costs[n])) {
         costs[n] = newCost;
         const newState: State = [newCost, state[1].concat([n]), n];

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,37 @@ export type Vertices = Record<Key, Vertex>;
  */
 export type Coordinates = Record<Key, Position>;
 
+export type DirectionBiasContext = {
+  /** Coordinate of the vertex being expanded. */
+  from: Position;
+  /** Coordinate of the neighbouring vertex being evaluated. */
+  to: Position;
+  /** Coordinate of the destination vertex. */
+  goal: Position;
+  /** Vector from the current vertex towards the neighbour. */
+  fromToVector: [number, number];
+  /** Vector from the current vertex towards the goal. */
+  fromGoalVector: [number, number];
+  /** Vector from the neighbour towards the goal. */
+  toGoalVector: [number, number];
+  /**
+   * The path (as vertex keys) that has been traversed so far, ending at the
+   * current vertex.
+   */
+  path: Key[];
+  /** The accumulated weight for the current vertex before evaluating the edge. */
+  cost: number;
+};
+
+export type PathFinderSearchOptions = {
+  /**
+   * Optional callback used to influence the traversal cost of each edge based
+   * on how well it aligns with the direction of the goal. Returning a positive
+   * number penalises the edge, while a negative number rewards it.
+   */
+  directionBias?: (context: DirectionBiasContext) => number;
+};
+
 export type PathFinderGraph<TEdgeData> = {
   vertices: Vertices;
   edgeData: Record<Key, Record<Key, TEdgeData | undefined>>;


### PR DESCRIPTION
## Summary
- add a searchOptions argument to PathFinder.findPath with a directionBias callback
- propagate direction bias information into the Dijkstra routine to tweak edge costs
- document the API change and add a train-focused example and regression test for forward bias

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2a0b9d748325a4f8d4ae09f34b4e