### PR TITLE
Handle Z dimension when rounding coordinates

### DIFF
--- a/src/round-coord.ts
+++ b/src/round-coord.ts
@@ -4,8 +4,14 @@ export default function roundCoord(
   coord: Position,
   tolerance: number
 ): Position {
-  return [
+  const rounded: Position = [
     Math.round(coord[0] / tolerance) * tolerance,
     Math.round(coord[1] / tolerance) * tolerance,
   ];
+
+  for (let i = 2; i < coord.length; i++) {
+    rounded[i] = coord[i];
+  }
+
+  return rounded;
 }


### PR DESCRIPTION
## Summary
- preserve Z coordinates when rounding geojson vertices so stacked crossings remain distinct

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d8b92c9b908325a07d3f4a4f12107a