### PR TITLE
Resolve 2D inputs against 3D graph vertices

### DIFF
--- a/test/linestring-3d.json
+++ b/test/linestring-3d.json
@@ -1,0 +1,16 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [0, 0, 0],
+          [1, 0, 5],
+          [2, 0, 10]
+        ]
+      }
+    }
+  ]
+}

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -4,6 +4,7 @@ import PathFinder from "../src/index";
 import geojson from "./network.json";
 import geojson66 from "./66.json";
 import largeNetwork from "./large-network.json";
+import linestring3d from "./linestring-3d.json";
 import { point } from "@turf/helpers";
 import distance from "@turf/distance";
 import osmWeight from "./osm-weight";
@@ -360,4 +361,16 @@ test("can route through large, complex one-way network", () => {
   expect(path).toBeTruthy();
   expect(path.path).toBeTruthy();
   expect(path.weight).toBeGreaterThan(0);
+});
+
+test("findPath maps 2D start and finish onto 3D vertices", () => {
+  const pathfinder = new PathFinder(linestring3d);
+  const path = pathfinder.findPath(point([0, 0]), point([2, 0]));
+
+  expect(path).toBeTruthy();
+  expect(path?.path).toEqual([
+    [0, 0, 0],
+    [1, 0, 5],
+    [2, 0, 10],
+  ]);
 });


### PR DESCRIPTION
## Summary
- add a vertex lookup helper that reconciles rounded coordinates with stored source coordinates
- use the helper when resolving start and finish points so 2D queries locate existing 3D vertices
- cover the new behaviour with a 3D line string fixture and vitest unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8c065ec8c8325834d90113702fbe5