### PR TITLE
Add transition guard support and heading-aware bias context

### DIFF
--- a/src/a-star.ts
+++ b/src/a-star.ts
@@ -17,9 +17,17 @@ type DirectionBiasEvaluator = (input: {
   path: Key[];
 }) => number;
 
+type TransitionGuardEvaluator = (input: {
+  cost: number;
+  from: Key;
+  to: Key;
+  path: Key[];
+}) => boolean;
+
 type Options = {
   directionBias?: DirectionBiasEvaluator;
   coordinates?: Coordinates;
+  transitionGuard?: TransitionGuardEvaluator;
   onNodeExpanded?: (context: { key: Key; cost: number }) => void;
 };
 
@@ -75,6 +83,18 @@ export default function findPath(
 
     const neighbours = graph[node];
     Object.keys(neighbours).forEach(function (n) {
+      if (
+        options.transitionGuard &&
+        options.transitionGuard({
+          cost,
+          from: node,
+          to: n,
+          path: state.path,
+        }) === false
+      ) {
+        return;
+      }
+
       const bias = options.directionBias
         ? options.directionBias({
             cost,

--- a/src/dijkstra.ts
+++ b/src/dijkstra.ts
@@ -10,8 +10,16 @@ type DirectionBiasEvaluator = (input: {
   path: Key[];
 }) => number;
 
+type TransitionGuardEvaluator = (input: {
+  cost: number;
+  from: Key;
+  to: Key;
+  path: Key[];
+}) => boolean;
+
 type Options = {
   directionBias?: DirectionBiasEvaluator;
+  transitionGuard?: TransitionGuardEvaluator;
   onNodeExpanded?: (context: { key: Key; cost: number }) => void;
 };
 
@@ -41,6 +49,18 @@ export default function findPath(
 
     const neighbours = graph[node];
     Object.keys(neighbours).forEach(function (n) {
+      if (
+        options.transitionGuard &&
+        options.transitionGuard({
+          cost,
+          from: node,
+          to: n,
+          path: state[1],
+        }) === false
+      ) {
+        return;
+      }
+
       const bias = options.directionBias
         ? options.directionBias({
             cost,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,10 @@ export type DirectionBiasContext = {
   fromGoalVector: [number, number];
   /** Vector from the neighbour towards the goal. */
   toGoalVector: [number, number];
+  /** Coordinate of the previous vertex on the path, when available. */
+  previous?: Position;
+  /** Vector from the previous vertex towards the current vertex, when available. */
+  previousToFromVector?: [number, number];
   /**
    * The path (as vertex keys) that has been traversed so far, ending at the
    * current vertex.
@@ -58,6 +62,8 @@ export type DirectionBiasContext = {
   cost: number;
 };
 
+export type TransitionGuardContext = DirectionBiasContext;
+
 export type PathFinderSearchOptions = {
   /**
    * Optional callback used to influence the traversal cost of each edge based
@@ -65,6 +71,12 @@ export type PathFinderSearchOptions = {
    * number penalises the edge, while a negative number rewards it.
    */
   directionBias?: (context: DirectionBiasContext) => number;
+  /**
+   * Optional callback used to veto a candidate transition entirely. Returning
+   * `false` prevents the neighbour from being explored, while throwing aborts
+   * the search.
+   */
+  transitionGuard?: (context: TransitionGuardContext) => boolean | void;
   /**
    * Selects which search algorithm should be used. Defaults to Dijkstra.
    */


### PR DESCRIPTION
## Summary
- expose previous heading data to direction bias callbacks and add a transition guard hook for rejecting moves outright
- ensure both Dijkstra and A* respect the new guard, and reuse traversal context construction in PathFinder
- document the new behaviours and add a regression test that blocks reversing paths through a turnout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daea8d17848325aad6306d4c19bf13