### PR TITLE
Add worker thread option for async path finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ const pathLineString = pathToGeoJSON(pathFinder.findPath(start, finish));
 
 (If `findPath` does not find a path, pathToGeoJSON will also return `undefined`.)
 
+### Asynchronous path searches
+
+When you need to resolve multiple paths at the same time you can enable the
+optional worker thread pool and use `findPathAsync`:
+
+```javascript
+const pathFinder = new PathFinder(geojson, {
+  worker: { enabled: true, poolSize: 4 },
+});
+
+const [a, b] = await Promise.all([
+  pathFinder.findPathAsync(pointA, pointB),
+  pathFinder.findPathAsync(pointC, pointD),
+]);
+
+await pathFinder.close();
+```
+
+When worker threads are unavailable, or when the search options contain
+callbacks such as `directionBias`, `findPathAsync` automatically falls back to
+the synchronous `findPath` implementation.
+
 ### Steering the search direction
 
 `findPath` accepts an optional third argument where you can provide search specific options. The
@@ -156,6 +178,11 @@ use to control the behaviour of the path finder. Available options:
   the routing graph; typically, this can be used for storing things like street names; if specified,
   the reduced data is present on found paths under the `edgeDatas` property
 - `edgeDataSeed` is a function returning taking a network feature's `properties` as argument and returning the seed used when reducing edge data with the `edgeDataReducer` above
+- `worker` enables path finding in [worker threads](#asynchronous-path-searches). The object accepts the following properties:
+  - `enabled` turns the worker pool on (default `false`).
+  - `poolSize` optionally limits the number of concurrent workers. When omitted
+    the available CPU core count is used. Worker threads are only used when the
+    search options do not provide callbacks.
 
 ## Weight functions
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,7 @@ export type PathFinderOptions<TEdgeReduce, TProperties> = {
   tolerance?: number;
   key?: (coordinates: Position) => string;
   compact?: boolean;
+  worker?: PathFinderWorkerOptions;
   /**
    * Calculate weight for an edge from a node at position a to a node at position b
    * @param {Position} a coordinate of node A
@@ -123,6 +124,19 @@ export type PathFinderOptions<TEdgeReduce, TProperties> = {
     }
   | {}
 );
+
+export type PathFinderWorkerOptions = {
+  /**
+   * Enables the worker thread pool used by {@link PathFinder.findPathAsync}.
+   * Defaults to `false`.
+   */
+  enabled?: boolean;
+  /**
+   * Maximum number of worker threads to spawn. When omitted, the number of
+   * available CPU cores is used.
+   */
+  poolSize?: number;
+};
 
 export type Path<TEdgeReduce> = {
   path: Position[];

--- a/src/worker-pool.ts
+++ b/src/worker-pool.ts
@@ -1,0 +1,295 @@
+import os from "os";
+import path from "path";
+import type { Worker } from "worker_threads";
+import type {
+  Key,
+  Path,
+  PathFinderGraph,
+  PathFinderWorkerOptions,
+} from "./types";
+
+export type WorkerSearchOptions = {
+  algorithm?: "dijkstra" | "astar";
+};
+
+export type WorkerInitData<TEdgeReduce> = {
+  graph: PathFinderGraph<TEdgeReduce>;
+  hasEdgeDataReducer: boolean;
+};
+
+export type WorkerRequest<TEdgeReduce> = {
+  id: number;
+  start: Key;
+  finish: Key;
+  searchOptions: WorkerSearchOptions;
+};
+
+export type WorkerResponse<TEdgeReduce> = {
+  id: number;
+  path?: Path<TEdgeReduce> | undefined;
+  error?: { message: string; stack?: string };
+};
+
+type PendingTask<TEdgeReduce> = {
+  request: WorkerRequest<TEdgeReduce>;
+  resolve: (path: Path<TEdgeReduce> | undefined) => void;
+  reject: (reason: unknown) => void;
+};
+
+type WorkerContainer<TEdgeReduce> = {
+  worker: Worker;
+  currentTask?: PendingTask<TEdgeReduce> & { id: number };
+};
+
+type WorkerPoolConfig<TEdgeReduce> = {
+  graph: PathFinderGraph<TEdgeReduce>;
+  hasEdgeDataReducer: boolean;
+  options?: PathFinderWorkerOptions;
+};
+
+let workerThreadsModule:
+  | (typeof import("worker_threads"))
+  | undefined;
+let workerThreadsChecked = false;
+
+function loadWorkerThreads():
+  | (typeof import("worker_threads"))
+  | undefined {
+  if (workerThreadsChecked) {
+    return workerThreadsModule;
+  }
+  workerThreadsChecked = true;
+
+  if (typeof process === "undefined" || !process.versions?.node) {
+    return undefined;
+  }
+
+  const requireFn: undefined | ((module: string) => unknown) =
+    typeof require === "function"
+      ? require
+      : Function(
+          "return typeof require !== 'undefined' ? require : undefined;"
+        )();
+
+  if (typeof requireFn !== "function") {
+    return undefined;
+  }
+
+  workerThreadsModule = requireFn("worker_threads") as typeof import("worker_threads");
+  return workerThreadsModule;
+}
+
+export function isWorkerThreadsAvailable() {
+  return Boolean(loadWorkerThreads());
+}
+
+const workerRelativePath = path.join("worker", "pathfinder-worker.js");
+
+function resolveWorkerSpecifier() {
+  if (typeof __dirname !== "undefined") {
+    return path.resolve(__dirname, workerRelativePath);
+  }
+
+  return undefined;
+}
+
+export default class PathFinderWorkerPool<TEdgeReduce> {
+  private readonly workerThreads = loadWorkerThreads();
+  private readonly workers: WorkerContainer<TEdgeReduce>[] = [];
+  private readonly idleWorkers: WorkerContainer<TEdgeReduce>[] = [];
+  private readonly queue: (PendingTask<TEdgeReduce> & { id: number })[] = [];
+  private readonly tasks = new Map<number, PendingTask<TEdgeReduce> & { id: number }>();
+  private readonly poolSize: number;
+  private readonly specifier: string | URL;
+  private nextId = 0;
+  private disposed = false;
+
+  constructor(private readonly config: WorkerPoolConfig<TEdgeReduce>) {
+    const specifier = resolveWorkerSpecifier();
+    if (!this.workerThreads || !specifier) {
+      throw new Error("Worker threads are not available on this platform.");
+    }
+    this.specifier = specifier;
+
+    const desiredSize = this.config.options?.poolSize;
+    this.poolSize = desiredSize && desiredSize > 0 ? desiredSize : Math.max(1, os.cpus()?.length ?? 1);
+
+    for (let i = 0; i < this.poolSize; i += 1) {
+      this._spawnWorker();
+    }
+  }
+
+  schedule(
+    start: Key,
+    finish: Key,
+    searchOptions: WorkerSearchOptions
+  ): Promise<Path<TEdgeReduce> | undefined> {
+    if (this.disposed) {
+      return Promise.reject(new Error("Worker pool has been closed."));
+    }
+
+    const id = this.nextId++;
+    const request: WorkerRequest<TEdgeReduce> = {
+      id,
+      start,
+      finish,
+      searchOptions,
+    };
+
+    return new Promise((resolve, reject) => {
+      const task: PendingTask<TEdgeReduce> & { id: number } = {
+        id,
+        request,
+        resolve,
+        reject,
+      };
+      this.tasks.set(id, task);
+      const worker = this.idleWorkers.pop();
+      if (worker) {
+        this._dispatch(worker, task);
+      } else {
+        this.queue.push(task);
+      }
+    });
+  }
+
+  async close() {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+
+    const closingError = new Error("Worker pool has been closed.");
+
+    this.queue.splice(0).forEach((task) => {
+      this.tasks.delete(task.id);
+      task.reject(closingError);
+    });
+
+    for (const container of this.workers) {
+      const current = container.currentTask;
+      if (current) {
+        this.tasks.delete(current.id);
+        current.reject(closingError);
+        container.currentTask = undefined;
+      }
+    }
+
+    this.tasks.clear();
+
+    await Promise.all(this.workers.map(({ worker }) => worker.terminate()));
+
+    this.workers.length = 0;
+    this.idleWorkers.length = 0;
+  }
+
+  private _spawnWorker() {
+    if (!this.workerThreads) {
+      return;
+    }
+
+    const worker = new this.workerThreads.Worker(this.specifier, {
+      workerData: {
+        graph: this.config.graph,
+        hasEdgeDataReducer: this.config.hasEdgeDataReducer,
+      } as WorkerInitData<TEdgeReduce>,
+    });
+
+    const container: WorkerContainer<TEdgeReduce> = { worker };
+    worker.on("message", (message: WorkerResponse<TEdgeReduce>) =>
+      this._handleMessage(container, message)
+    );
+    worker.on("error", (error) => this._handleError(container, error));
+    worker.on("exit", (code) => this._handleExit(container, code));
+
+    this.workers.push(container);
+    const nextTask = this.queue.shift();
+    if (nextTask) {
+      this._dispatch(container, nextTask);
+    } else {
+      this.idleWorkers.push(container);
+    }
+  }
+
+  private _dispatch(
+    container: WorkerContainer<TEdgeReduce>,
+    task: PendingTask<TEdgeReduce> & { id: number }
+  ) {
+    container.currentTask = task;
+    container.worker.postMessage(task.request);
+  }
+
+  private _release(container: WorkerContainer<TEdgeReduce>) {
+    container.currentTask = undefined;
+    if (this.disposed) {
+      return;
+    }
+
+    const nextTask = this.queue.shift();
+    if (nextTask) {
+      this._dispatch(container, nextTask);
+    } else {
+      this.idleWorkers.push(container);
+    }
+  }
+
+  private _handleMessage(
+    container: WorkerContainer<TEdgeReduce>,
+    message: WorkerResponse<TEdgeReduce>
+  ) {
+    const task = this.tasks.get(message.id);
+    if (!task) {
+      this._release(container);
+      return;
+    }
+
+    this.tasks.delete(message.id);
+
+    if (message.error) {
+      const error = new Error(message.error.message);
+      if (message.error.stack) {
+        error.stack = message.error.stack;
+      }
+      task.reject(error);
+    } else {
+      task.resolve(message.path);
+    }
+
+    this._release(container);
+  }
+
+  private _handleError(container: WorkerContainer<TEdgeReduce>, error: unknown) {
+    const task = container.currentTask;
+    if (task) {
+      this.tasks.delete(task.id);
+      task.reject(error);
+    }
+    this._removeWorker(container);
+    if (!this.disposed) {
+      this._spawnWorker();
+    }
+  }
+
+  private _handleExit(container: WorkerContainer<TEdgeReduce>, code: number) {
+    const task = container.currentTask;
+    if (task) {
+      this.tasks.delete(task.id);
+      task.reject(new Error("Worker terminated unexpectedly."));
+    }
+    this._removeWorker(container);
+    if (!this.disposed && code !== 0) {
+      this._spawnWorker();
+    }
+  }
+
+  private _removeWorker(container: WorkerContainer<TEdgeReduce>) {
+    const index = this.workers.indexOf(container);
+    if (index >= 0) {
+      this.workers.splice(index, 1);
+    }
+    const idleIndex = this.idleWorkers.indexOf(container);
+    if (idleIndex >= 0) {
+      this.idleWorkers.splice(idleIndex, 1);
+    }
+  }
+}

--- a/src/worker/pathfinder-worker.ts
+++ b/src/worker/pathfinder-worker.ts
@@ -1,0 +1,47 @@
+import { parentPort, workerData } from "worker_threads";
+import type { GeoJsonProperties } from "geojson";
+import PathFinder from "..";
+import type {
+  WorkerInitData,
+  WorkerRequest,
+  WorkerResponse,
+} from "../worker-pool";
+
+const data = workerData as WorkerInitData<unknown>;
+
+const pathFinder = new PathFinder<unknown, GeoJsonProperties>(
+  data.graph,
+  {},
+  {
+    hasEdgeDataReducer: data.hasEdgeDataReducer,
+    disableWorkerPool: true,
+  }
+);
+
+const port = parentPort;
+if (!port) {
+  throw new Error("Worker threads require a parent port.");
+}
+
+port.on("message", (message: WorkerRequest<unknown>) => {
+  try {
+    const result = pathFinder.findPathFromVertexKeys(
+      message.start,
+      message.finish,
+      message.searchOptions
+    );
+    const response: WorkerResponse<unknown> = {
+      id: message.id,
+      path: result,
+    };
+    port.postMessage(response);
+  } catch (error) {
+    const err =
+      error instanceof Error ? error : new Error(String(error ?? "Unknown error"));
+    const response: WorkerResponse<unknown> = {
+      id: message.id,
+      error: { message: err.message, stack: err.stack },
+    };
+    port.postMessage(response);
+  }
+});

--- a/test/path.spec.js
+++ b/test/path.spec.js
@@ -245,6 +245,65 @@ test("direction bias favours moving toward the destination", () => {
   expect(unbiased.weight).toBeLessThan(biased.weight);
 });
 
+test("can find multiple paths concurrently using worker threads", async () => {
+  const network = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+          ],
+        },
+      },
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [1, 1],
+            [2, 1],
+          ],
+        },
+      },
+    ],
+  };
+
+  const pathfinder = new PathFinder(network, {
+    worker: { enabled: true, poolSize: 2 },
+  });
+
+  const [pathA, pathB] = await Promise.all([
+    pathfinder.findPathAsync(point([0, 0]), point([1, 1])),
+    pathfinder.findPathAsync(point([1, 0]), point([2, 1])),
+  ]);
+
+  expect(pathA).toBeTruthy();
+  expect(pathB).toBeTruthy();
+  await pathfinder.close();
+});
+
+test("findPathAsync falls back to synchronous behaviour when callbacks are provided", async () => {
+  const pathfinder = new PathFinder(geojson, {
+    worker: { enabled: true, poolSize: 2 },
+  });
+
+  const result = await pathfinder.findPathAsync(
+    point([8.44460166, 59.48947469]),
+    point([8.44651, 59.513920000000006]),
+    {
+      directionBias: () => 0,
+    }
+  );
+
+  expect(result).toBeTruthy();
+  await pathfinder.close();
+});
+
 test("transition guard blocks reversing moves", () => {
   const network = {
     type: "FeatureCollection",


### PR DESCRIPTION
## Summary
- add a worker thread pool and worker entrypoint to resolve graph searches concurrently
- expose a new findPathAsync helper plus close() and worker options on PathFinder
- document the asynchronous API and cover it with new Vitest scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db1f31bf988325a4f22ecc1e7893f5