### PR TITLE
Add worker-thread powered async path finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ const pathLineString = pathToGeoJSON(pathFinder.findPath(start, finish));
 
 (If `findPath` does not find a path, pathToGeoJSON will also return `undefined`.)
 
+### Parallel path searches
+
+When running in Node.js you can process multiple route calculations in parallel
+by enabling worker threads. Provide a `concurrency` value greater than `1` when
+creating the `PathFinder`, then call the asynchronous `findPathAsync` method:
+
+```javascript
+const pathFinder = new PathFinder(geojson, { concurrency: 4 });
+const [first, second] = await Promise.all([
+  pathFinder.findPathAsync(startA, finishA),
+  pathFinder.findPathAsync(startB, finishB),
+]);
+```
+
+The asynchronous API falls back to the main thread whenever worker threads are
+unavailable or when a request uses callbacks such as `directionBias` or
+`onNodeExpanded`. Custom `key` or `edgeDataReducer` options are also not
+compatible with worker execution.
+
 ### Steering the search direction
 
 `findPath` accepts an optional third argument where you can provide search specific options. The
@@ -105,6 +124,8 @@ use to control the behaviour of the path finder. Available options:
 - `tolerance` (default `1e-5`) controls the tolerance for how close vertices in the GeoJSON can be
   before considered being the same vertice; you can say that coordinates closer than this will be
   snapped together into one coordinate
+- `concurrency` enables `findPathAsync` to use the specified number of worker
+  threads. Values lower than `2` disable worker execution.
 - `edgeDataReducer` can optionally be used to store data present in the GeoJSON on each edge of
   the routing graph; typically, this can be used for storing things like street names; if specified,
   the reduced data is present on found paths under the `edgeDatas` property

--- a/src/threading/find-path.worker.ts
+++ b/src/threading/find-path.worker.ts
@@ -1,0 +1,46 @@
+import { parentPort, workerData } from "node:worker_threads";
+import PathFinder from "../index";
+import type { PathFinderSearchOptions } from "../types";
+import type {
+  WorkerInitData,
+  WorkerRequestPayload,
+  WorkerResponsePayload,
+} from "./worker-types";
+
+const initData = workerData as WorkerInitData<unknown> | undefined;
+const port = parentPort;
+
+if (!port || !initData) {
+  throw new Error("PathFinder worker initialisation failed");
+}
+
+const pathFinder = new PathFinder(
+  initData.graph,
+  {
+    tolerance: initData.options.tolerance,
+  },
+  { preprocessed: true }
+);
+
+port.on("message", (message: WorkerRequestPayload<unknown>) => {
+  const response: WorkerResponsePayload<unknown> = { id: message.id };
+  try {
+    response.result = pathFinder.findPath(
+      message.start,
+      message.finish,
+      message.searchOptions as PathFinderSearchOptions
+    );
+  } catch (error) {
+    if (error instanceof Error) {
+      response.error = {
+        message: error.message,
+        stack: error.stack,
+      };
+    } else {
+      response.error = {
+        message: String(error),
+      };
+    }
+  }
+  port.postMessage(response);
+});

--- a/src/threading/worker-pool.ts
+++ b/src/threading/worker-pool.ts
@@ -1,0 +1,158 @@
+import type { Worker, WorkerOptions } from "node:worker_threads";
+import type { Feature, Point } from "geojson";
+import type { Path, PathFinderSearchOptions } from "../types";
+import type {
+  WorkerInitData,
+  WorkerRequestPayload,
+  WorkerResponsePayload,
+} from "./worker-types";
+
+type WorkerConstructor = new (
+  filename: string | URL,
+  options?: WorkerOptions
+) => Worker;
+
+type PendingTask<TEdgeReduce> = {
+  resolve: (value: Path<TEdgeReduce> | undefined) => void;
+  reject: (reason?: unknown) => void;
+};
+
+export default class PathFinderWorkerPool<TEdgeReduce> {
+  private readonly workers: Worker[] = [];
+  private readonly idleWorkers: Worker[] = [];
+  private readonly queue: WorkerRequestPayload<TEdgeReduce>[] = [];
+  private readonly pending = new Map<number, PendingTask<TEdgeReduce>>();
+  private readonly activeTask = new Map<Worker, number>();
+  private nextTaskId = 0;
+  private destroyed = false;
+
+  constructor(
+    private readonly WorkerCtor: WorkerConstructor,
+    private readonly scriptPath: string,
+    initData: WorkerInitData<TEdgeReduce>,
+    workerCount: number
+  ) {
+    const size = Math.max(1, Math.floor(workerCount));
+    for (let i = 0; i < size; i++) {
+      const worker = new this.WorkerCtor(this.scriptPath, {
+        workerData: initData,
+      });
+      this.workers.push(worker);
+      this.idleWorkers.push(worker);
+      worker.on("message", (message: WorkerResponsePayload<TEdgeReduce>) =>
+        this.handleMessage(worker, message)
+      );
+      worker.on("error", (error) => this.handleWorkerError(worker, error));
+      worker.on("exit", (code) => this.handleWorkerExit(worker, code));
+    }
+  }
+
+  run(
+    start: Feature<Point>,
+    finish: Feature<Point>,
+    searchOptions: PathFinderSearchOptions
+  ): Promise<Path<TEdgeReduce> | undefined> {
+    if (this.destroyed) {
+      return Promise.reject(new Error("Worker pool has been terminated"));
+    }
+
+    return new Promise<Path<TEdgeReduce> | undefined>((resolve, reject) => {
+      const id = this.nextTaskId++;
+      this.pending.set(id, { resolve, reject });
+      this.queue.push({ id, start, finish, searchOptions });
+      this.flush();
+    });
+  }
+
+  async destroy(): Promise<void> {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    const pendingErrors = new Error("Worker pool terminated");
+    for (const [, task] of this.pending) {
+      task.reject(pendingErrors);
+    }
+    this.pending.clear();
+    this.queue.length = 0;
+
+    await Promise.allSettled(this.workers.map((worker) => worker.terminate()));
+  }
+
+  private flush() {
+    while (this.idleWorkers.length > 0 && this.queue.length > 0) {
+      const worker = this.idleWorkers.pop();
+      if (!worker) {
+        return;
+      }
+      const payload = this.queue.shift();
+      if (!payload) {
+        this.idleWorkers.push(worker);
+        return;
+      }
+      this.activeTask.set(worker, payload.id);
+      worker.postMessage(payload);
+    }
+  }
+
+  private handleMessage(
+    worker: Worker,
+    message: WorkerResponsePayload<TEdgeReduce>
+  ) {
+    const pendingTask = this.pending.get(message.id);
+    if (!pendingTask) {
+      return;
+    }
+    this.pending.delete(message.id);
+    this.activeTask.delete(worker);
+    if (message.error) {
+      const error = new Error(message.error.message);
+      error.stack = message.error.stack;
+      pendingTask.reject(error);
+    } else {
+      pendingTask.resolve(message.result);
+    }
+    if (!this.destroyed) {
+      this.idleWorkers.push(worker);
+      this.flush();
+    }
+  }
+
+  private handleWorkerError(worker: Worker, error: Error) {
+    this.failActiveTask(worker, error);
+    this.removeWorker(worker);
+  }
+
+  private handleWorkerExit(worker: Worker, code: number) {
+    if (code !== 0) {
+      this.failActiveTask(
+        worker,
+        new Error(`Worker exited with code ${code}`)
+      );
+    }
+    this.removeWorker(worker);
+  }
+
+  private failActiveTask(worker: Worker, error: Error) {
+    const taskId = this.activeTask.get(worker);
+    if (taskId === undefined) {
+      return;
+    }
+    this.activeTask.delete(worker);
+    const pendingTask = this.pending.get(taskId);
+    if (!pendingTask) {
+      return;
+    }
+    this.pending.delete(taskId);
+    pendingTask.reject(error);
+  }
+
+  private removeWorker(worker: Worker) {
+    const idleIndex = this.idleWorkers.indexOf(worker);
+    if (idleIndex >= 0) {
+      this.idleWorkers.splice(idleIndex, 1);
+    }
+    const workerIndex = this.workers.indexOf(worker);
+    if (workerIndex >= 0) {
+      this.workers.splice(workerIndex, 1);
+    }
+  }
+}

--- a/src/threading/worker-types.ts
+++ b/src/threading/worker-types.ts
@@ -1,0 +1,27 @@
+import type { Feature, Point } from "geojson";
+import type { Path, PathFinderGraph, PathFinderSearchOptions } from "../types";
+
+export type ThreadSafePathFinderOptions = {
+  tolerance?: number;
+};
+
+export type WorkerInitData<TEdgeReduce> = {
+  graph: PathFinderGraph<TEdgeReduce>;
+  options: ThreadSafePathFinderOptions;
+};
+
+export type WorkerRequestPayload<TEdgeReduce> = {
+  id: number;
+  start: Feature<Point>;
+  finish: Feature<Point>;
+  searchOptions: PathFinderSearchOptions;
+};
+
+export type WorkerResponsePayload<TEdgeReduce> = {
+  id: number;
+  result?: Path<TEdgeReduce> | undefined;
+  error?: {
+    message: string;
+    stack?: string;
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,11 @@ export type PathFinderOptions<TEdgeReduce, TProperties> = {
   key?: (coordinates: Position) => string;
   compact?: boolean;
   /**
+   * Number of worker threads that should be used to evaluate `findPathAsync`
+   * calls in parallel. Values lower than 2 disable multithreading.
+   */
+  concurrency?: number;
+  /**
    * Calculate weight for an edge from a node at position a to a node at position b
    * @param {Position} a coordinate of node A
    * @param {Position} b coordinate of node B


### PR DESCRIPTION
## Summary
- add a worker-thread powered `findPathAsync` API backed by an optional concurrency option
- implement a worker pool and messaging contract for parallel path computations
- document the new feature and cover it with Vitest concurrency regressions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0b3fe68788325a8875be20c30a106